### PR TITLE
remove workspace token

### DIFF
--- a/vantagev2/models/post_access_grants.go
+++ b/vantagev2/models/post_access_grants.go
@@ -31,10 +31,6 @@ type PostAccessGrants struct {
 	// The token of the Team you want to grant access to.
 	// Required: true
 	TeamToken *string `json:"team_token"`
-
-	// The token of the Workspace the resource belongs to.
-	// Required: true
-	WorkspaceToken *string `json:"workspace_token"`
 }
 
 // Validate validates this post access grants
@@ -50,10 +46,6 @@ func (m *PostAccessGrants) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateTeamToken(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateWorkspaceToken(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -117,15 +109,6 @@ func (m *PostAccessGrants) validateResourceToken(formats strfmt.Registry) error 
 func (m *PostAccessGrants) validateTeamToken(formats strfmt.Registry) error {
 
 	if err := validate.Required("team_token", "body", m.TeamToken); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PostAccessGrants) validateWorkspaceToken(formats strfmt.Registry) error {
-
-	if err := validate.Required("workspace_token", "body", m.WorkspaceToken); err != nil {
 		return err
 	}
 

--- a/vantagev2/swagger.json
+++ b/vantagev2/swagger.json
@@ -3840,10 +3840,6 @@
           "type": "string",
           "description": "The token of the Team you want to grant access to."
         },
-        "workspace_token": {
-          "type": "string",
-          "description": "The token of the Workspace the resource belongs to."
-        },
         "access": {
           "type": "string",
           "description": "The access level you want to grant. Defaults to 'allowed'.",
@@ -3855,8 +3851,7 @@
       },
       "required": [
         "resource_token",
-        "team_token",
-        "workspace_token"
+        "team_token"
       ],
       "description": "Create an Access Grant."
     },


### PR DESCRIPTION
this version of the library uses a schema that will be available when https://github.com/vantage-sh/core/pull/6604 is deployed.

i'm using the changes in this branch to work on https://github.com/vantage-sh/terraform-provider-vantage/pull/new/andy/access-grants