### PR TITLE
chore: Bring back links in /v2/tags endpoint.

### DIFF
--- a/vantagev2/models/tags.go
+++ b/vantagev2/models/tags.go
@@ -19,6 +19,9 @@ import (
 // swagger:model Tags
 type Tags struct {
 
+	// links
+	Links interface{} `json:"links,omitempty"`
+
 	// tags
 	Tags []*Tag `json:"tags"`
 }

--- a/vantagev2/swagger.json
+++ b/vantagev2/swagger.json
@@ -14215,6 +14215,9 @@
     "Tags": {
       "type": "object",
       "properties": {
+        "links": {
+          "type": "object"
+        },
         "tags": {
           "type": "array",
           "items": {


### PR DESCRIPTION
Assume there was some sort of race condition in how we fetched the swagger.json file last time.