### PR TITLE
fix(ci): avoid force-with-lease stale info when sync branch exists

### DIFF
--- a/.github/workflows/sync-from-core.yml
+++ b/.github/workflows/sync-from-core.yml
@@ -65,6 +65,10 @@ jobs:
           git commit -m "chore: regenerate API client" \
             -m "Generated against ${VANTAGE_HOST}."
 
+          # Populate the remote-tracking ref so --force-with-lease has a lease
+          # value when the branch already exists on origin.
+          git fetch origin "$BRANCH" || true
+
           git push -u origin "$BRANCH" --force-with-lease
 
           DEFAULT_BRANCH="$(gh api "repos/${{ github.repository }}" --jq '.default_branch')"


### PR DESCRIPTION
## Summary

Fetch the sync branch (best-effort) before `git push --force-with-lease` in `sync-from-core.yml` so the lease has a local remote-tracking ref to compare against.

## Why

Seen in [this run](https://github.com/vantage-sh/vantage-go/actions) while regenerating against the updated core swagger:

```
! [rejected]        sync/api-client-acab89b -> sync/api-client-acab89b (stale info)
error: failed to push some refs to 'https://github.com/vantage-sh/vantage-go'
```

The SDK workflow names its branch `sync/api-client-<short-sha>`. When the same core SHA triggers a second regen (or a previous run left a dangling `sync/api-client-<sha>` branch), the branch already exists on `origin`, but the fresh CI clone only fetched `main` and has no `refs/remotes/origin/sync/api-client-<sha>`. `--force-with-lease` without an explicit expected value needs that remote-tracking ref to check the lease, so it refuses the push with `(stale info)`.

`git fetch origin "$BRANCH" || true` is a no-op when the branch doesn't yet exist on origin (first push) and populates the remote-tracking ref when it does, which is exactly what the lease check needs. We keep `--force-with-lease` instead of falling back to `--force` so the guard still fires if a human pushed a newer commit to the same branch between fetch and push.
