### PR TITLE
chore: regenerate API client from production swagger

### DIFF
--- a/vantagev2/models/cost.go
+++ b/vantagev2/models/cost.go
@@ -56,7 +56,7 @@ type Cost struct {
 
 	// The cost provider which incurred the cost.
 	// Example: aws
-	// Enum: ["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal"]
+	// Enum: ["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal","eleven_labs"]
 	Provider *string `json:"provider,omitempty"`
 
 	// The region which incurred the cost.
@@ -171,7 +171,7 @@ var costTypeProviderPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal","eleven_labs"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -279,6 +279,9 @@ const (
 
 	// CostProviderModal captures enum value "modal"
 	CostProviderModal string = "modal"
+
+	// CostProviderElevenLabs captures enum value "eleven_labs"
+	CostProviderElevenLabs string = "eleven_labs"
 )
 
 // prop value enum

--- a/vantagev2/models/forecasted_cost.go
+++ b/vantagev2/models/forecasted_cost.go
@@ -36,7 +36,7 @@ type ForecastedCost struct {
 	// The cost provider which incurred the cost. Will be 'all' for all combined providers.
 	// Example: aws
 	// Required: true
-	// Enum: ["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal","all"]
+	// Enum: ["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal","eleven_labs","all"]
 	Provider string `json:"provider"`
 
 	// The service for the forecasted cost. Will be 'all' for all combined services
@@ -116,7 +116,7 @@ var forecastedCostTypeProviderPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal","all"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["aws","azure","gcp","snowflake","databricks","mongo","datadog","fastly","new_relic","opencost","open_ai","oracle","confluent","planetscale","coralogix","kubernetes","custom_provider","github","linode","grafana","clickhouse","temporal","twilio","azure_csp","kubernetes_agent","anthropic","anyscale","cursor","elastic","vercel","redis_cloud","circle_ci","modal","eleven_labs","all"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -224,6 +224,9 @@ const (
 
 	// ForecastedCostProviderModal captures enum value "modal"
 	ForecastedCostProviderModal string = "modal"
+
+	// ForecastedCostProviderElevenLabs captures enum value "eleven_labs"
+	ForecastedCostProviderElevenLabs string = "eleven_labs"
 
 	// ForecastedCostProviderAll captures enum value "all"
 	ForecastedCostProviderAll string = "all"

--- a/vantagev2/swagger.json
+++ b/vantagev2/swagger.json
@@ -4034,7 +4034,8 @@
               "vercel",
               "redis_cloud",
               "circle_ci",
-              "modal"
+              "modal",
+              "eleven_labs"
             ],
             "required": false
           },
@@ -4609,6 +4610,7 @@
               "redis_cloud",
               "circle_ci",
               "modal",
+              "eleven_labs",
               "all"
             ],
             "required": false
@@ -6370,7 +6372,8 @@
               "vercel",
               "redis_cloud",
               "circle_ci",
-              "modal"
+              "modal",
+              "eleven_labs"
             ],
             "required": false
           },
@@ -11669,7 +11672,8 @@
                 "vercel",
                 "redis_cloud",
                 "circle_ci",
-                "modal"
+                "modal",
+                "eleven_labs"
               ]
             },
             "required": false
@@ -11899,7 +11903,8 @@
                 "vercel",
                 "redis_cloud",
                 "circle_ci",
-                "modal"
+                "modal",
+                "eleven_labs"
               ]
             },
             "required": false
@@ -17229,6 +17234,7 @@
             "redis_cloud",
             "circle_ci",
             "modal",
+            "eleven_labs",
             "all"
           ],
           "x-nullable": false,
@@ -17905,7 +17911,8 @@
             "vercel",
             "redis_cloud",
             "circle_ci",
-            "modal"
+            "modal",
+            "eleven_labs"
           ],
           "x-nullable": true,
           "description": "The cost provider which incurred the cost."


### PR DESCRIPTION
## Summary

- Regenerates the v2 client from `https://api.vantage.sh/v2/swagger.json` (via `VANTAGE_HOST=https://api.vantage.sh make generate`).
- Adds `eleven_labs` to provider enum values in `Cost` / `ForecastedCost` models and `swagger.json`.

This is **PR 1 of 2** for ENG-2390 canvas Terraform support:

1. **This PR** — keep `vantage-go` aligned with production swagger (catch-up / drift).
2. **Follow-up PR** (after core canvas entity changes merge) — regen from prod again to pick up `is_refreshing`, `refreshed_at`, and typed `CanvasData` / `CanvasTable` models.

Note: the larger catch-up (canvas CRUD client, `default_forecast`, virtual tag config updates, etc.) already landed on `main` via #72.

## Test plan

- [x] `go build ./...`
- [ ] CI green


Made with [Cursor](https://cursor.com)